### PR TITLE
Enable client to configure host, port, exec and path

### DIFF
--- a/lib/mongo-import/snapshot.rb
+++ b/lib/mongo-import/snapshot.rb
@@ -1,7 +1,8 @@
 module MongoImport
   def snapshot(expr, opts={})
     db, collection = expr.split('.')
-    Snapshot.new(expr, :db => opts[:db] || db, :collection => opts[:collection] || collection).import
+    opts = { db: db, collection: collection }.merge(opts)
+    Snapshot.new(expr, opts).import
   end
 
   class Snapshot

--- a/spec/lib/mongo-import/snapshot_spec.rb
+++ b/spec/lib/mongo-import/snapshot_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+describe MongoImport, 'snapshot' do
+  it 'should pass all options to Snapshot ctor' do
+    options = { db: 'db', collection: 'coll', foo: 'bar' }
+
+    MongoImport::Snapshot.should_receive(:new) do |expr, opts|
+      opts[:db].should == 'db'
+      opts[:collection].should == 'coll'
+      opts[:foo].should == 'bar'
+      double('snapshot').as_null_object
+    end
+
+    snapshot = snapshot('expr', options)
+  end
+
+  it 'should take db and collection from expr when no passed in options' do
+    MongoImport::Snapshot.should_receive(:new) do |expr, opts|
+      opts[:db].should == 'db'
+      opts[:collection].should == 'coll'
+      double('snapshot').as_null_object
+    end
+
+    snapshot = snapshot('db.coll', {})
+  end
+end


### PR DESCRIPTION
Now client can override default host, port exec and path options.
